### PR TITLE
Javascript build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 *.class
 .idea
 classes*
+node_modules

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ and FluentLenium+Rest-Assured acceptance tests running in a headless browser (no
 # Table of Contents
 
 - [Installation and running](#installation-and-running)
+- [Project Dependencies](#project-dependencies)
 - [Deploying your app to a jetty / tomcat server](#deploying-your-app-to-a-jetty--tomcat-server)
 - [Running tests](#running-tests)
 - [Setting up Jenkins CI (with vagrant, virtualbox, chef)](#setting-up-jenkins-ci-with-vagrant-virtualbox-chef)
@@ -22,6 +23,20 @@ and FluentLenium+Rest-Assured acceptance tests running in a headless browser (no
     - [Acceptance tests using a mocked server](#acceptance-tests-using-a-mocked-server)
     - [Running app with embedded tomcat server at different log levels](#running-app-with-embedded-tomcat-server-at-different-log-levels)
 - [Additional notes](#additional-notes)
+
+## Project Dependencies
+
+This project has a few dependencies for building and testing Javascript that need to be installed
+separately from gradle. Once you have them, the gradle build tasks will use them to build your javascript.
+
+- Gulp is a task runner for Javascript, and will be used for building, concatenating, minifying, and testing
+the Javascript. You will use NPM to install Gulp.
+- NPM is the Node package manager, and will be used for managing Javascript dependencies
+
+1. `brew install node`
+1. `npm install -g npm gulp` (Node comes with NPM, this uses NPM to update itself and install gulp)
+1. `cd components/users`
+1. `npm install`
 
 ## Installation and running
 

--- a/applications/core/src/main/java/com/websiteskeleton/core/WebMvcConfiguration.java
+++ b/applications/core/src/main/java/com/websiteskeleton/core/WebMvcConfiguration.java
@@ -11,15 +11,15 @@ public class WebMvcConfiguration extends WebMvcConfigurerAdapter {
     @Bean
     public ViewResolver viewResolver() {
         InternalResourceViewResolver jspResolver = new InternalResourceViewResolver();
-        jspResolver.setPrefix("/");
+        jspResolver.setPrefix("/views/");
         jspResolver.setSuffix(".jsp");
         return jspResolver;
     }
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/css/**").addResourceLocations("/css/");
-        registry.addResourceHandler("/js/**").addResourceLocations("/js/");
-        registry.addResourceHandler("/img/**").addResourceLocations("/img/");
+        registry.addResourceHandler("/styles/**").addResourceLocations("classpath:/META-INF/resources/css/");
+        registry.addResourceHandler("/js/**").addResourceLocations("classpath:/META-INF/resources/js/");
+        registry.addResourceHandler("/img/**").addResourceLocations("classpath:/META-INF/resources/img/");
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,6 @@ subprojects {
     apply plugin: 'java'
 
     repositories {
-        maven {
-            url 'https://repo.spring.io/libs-release'
-        }
         mavenCentral()
     }
 

--- a/components/products/build.gradle
+++ b/components/products/build.gradle
@@ -1,8 +1,9 @@
 dependencies {
     compile(
-        "org.slf4j:slf4j-api:$slf4jVersion",
-        'javax.servlet:javax.servlet-api:3.1.0',
-        'com.fasterxml.jackson.core:jackson-databind:2.6.1'
+            "org.slf4j:slf4j-api:$slf4jVersion",
+            'javax.servlet:javax.servlet-api:3.1.0',
+            'com.fasterxml.jackson.core:jackson-databind:2.6.1',
+            'com.jayway.restassured:rest-assured:2.5.0'
     )
 
     springCompile('spring-context')

--- a/components/users/.gitignore
+++ b/components/users/.gitignore
@@ -1,0 +1,2 @@
+src/main/resources/META-INF/resources/css/*
+src/main/resources/META-INF/resources/js/*

--- a/components/users/build.gradle
+++ b/components/users/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'be.filipblondeel.gradle:gradle-gulp-plugin:0.1'
+    }
+}
+
+apply plugin: 'gulp'
+
 dependencies {
     ext {
         seleniumVersion = '2.47.1'
@@ -48,3 +59,5 @@ task unitTest(type: Test) {
     include 'unit/**'
     exclude 'acceptance/**'
 }
+
+assemble.dependsOn gulp_build

--- a/components/users/config.js
+++ b/components/users/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    apiUrl: '<% apiUrl %>'
+};

--- a/components/users/environment.js
+++ b/components/users/environment.js
@@ -1,0 +1,10 @@
+module.exports = {
+    dev: {
+        apiUrl: 'http://localhost:3030',
+        env: 'dev'
+    },
+    test: {
+        apiUrl: 'http://localhost:3031',
+        env: 'test'
+    }
+};

--- a/components/users/gulpfile.js
+++ b/components/users/gulpfile.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// Gulp Dependencies
+var gulp = require('gulp');
+var sass = require('gulp-sass');
+var concat = require('gulp-concat');
+var replace = require('gulp-replace');
+var karma = require('gulp-karma');
+
+var browserify = require('browserify');
+var source = require('vinyl-source-stream');
+
+
+// Other Dependencies
+var yargs = require('yargs').argv;
+
+// Environment Setup
+var ENVS = require('./environment');
+var env = ENVS.dev;
+var passedArg = 'dev';
+var buildDir = "./src/main/resources/META-INF/resources";
+
+/* SCSS*/
+gulp.task('scss', function () {
+    gulp.src('./src/main/scss/**/*.scss')
+        .pipe(sass().on('error', function (err) {
+            console.error(err);
+        }))
+        .pipe(concat('app.css'))
+        .pipe(gulp.dest(buildDir + '/css/'));
+});
+
+/* JavaScript */
+gulp.task('browserify:js', ['config'], function () {
+    return browserify('./src/main/javascript/app.js').bundle()
+        // vinyl-source-stream makes the bundle compatible with gulp
+        .pipe(source('app.js'))
+        .pipe(gulp.dest(buildDir + '/js/'));
+});
+/* CoffeeScript */
+gulp.task('browserify:coffee', function () {
+    return browserify('./src/main/coffeescript/app.coffee').transform('coffeeify').bundle()
+        // vinyl-source-stream makes the bundle compatible with gulp
+        .pipe(source('app.coffee.js'))
+        .pipe(gulp.dest(buildDir + '/js/'));
+});
+gulp.task('browserify', ['browserify:js', 'browserify:coffee']);
+
+// Vendor node components with artifacts
+gulp.task('vendor:javascript', function () {
+    gulp.src([
+        './node_modules/jquery/dist/jquery.min.js',
+        './node_modules/bootstrap/dist/js/bootstrap.min.js'
+    ]).pipe(concat('vendor.js'))
+        .pipe(gulp.dest(buildDir + '/js/'))
+});
+gulp.task('vendor:styles', function () {
+    gulp.src([
+        './node_modules/bootstrap/dist/css/bootstrap.min.css',
+        './node_modules/bootstrap/dist/css/bootstrap-theme.min.css'
+    ]).pipe(concat('vendor.css'))
+        .pipe(gulp.dest(buildDir + '/css/'))
+});
+gulp.task('vendor', ['vendor:javascript', 'vendor:styles']);
+
+/* Environment based config */
+gulp.task('config', ['environment'], function () {
+    gulp.src('./config.js')
+        .pipe(replace('<% apiUrl %>', env.apiUrl))
+        .pipe(gulp.dest('./src/main/javascript'));
+});
+
+/* Environment Tasks */
+gulp.task('environment', function () {
+    if (yargs.env !== undefined && ENVS[yargs.env] !== undefined) {
+        env = ENVS[yargs.env];
+        passedArg = yargs.env;
+    }
+});
+
+/* Testing Tasks */
+gulp.task('karma', ['build'], function (done) {
+    var files = [
+        //TODO: figure this out
+    ];
+    if (yargs.f !== undefined) {
+        files.push(yargs.f);
+    } else {
+        files.push('./src/test/coffeescript/**/*.coffee');
+    }
+    gulp.src(files).pipe(karma({
+        files: files,
+        configFile: __dirname + '/spec/karma.conf.coffee',
+        singleRun: true
+    })).on('error', function (err) {
+        process.exit(1);
+    });
+});
+
+gulp.task('karma:run', ['reset'], function () {
+    gulp.start('karma');
+});
+
+gulp.task('test', function () {
+    yargs.env = 'test';
+    gulp.start('karma:run');
+});
+
+/* Default Tasks */
+gulp.task('build', ['environment', 'config', 'scss', 'vendor', 'browserify']);
+gulp.task('default', ['build']);

--- a/components/users/package.json
+++ b/components/users/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "users",
+  "version": "1.0.0",
+  "description": "Users Component",
+  "dependencies": {
+    "bootstrap": "^3.3.5",
+    "domready": "^1.0.8",
+    "jquery": "^2.1.4"
+  },
+  "devDependencies": {
+    "browserify": "^11.0.1",
+    "coffeeify": "^1.1.0",
+    "gulp": "^3.9.0",
+    "gulp-concat": "^2.6.0",
+    "gulp-karma": "0.0.4",
+    "gulp-replace": "^0.5.4",
+    "gulp-sass": "^2.0.4",
+    "karma": "^0.13.9",
+    "vinyl-source-stream": "^1.1.0",
+    "yargs": "^3.24.0"
+  }
+}

--- a/components/users/src/main/coffeescript/app.coffee
+++ b/components/users/src/main/coffeescript/app.coffee
@@ -1,0 +1,5 @@
+domready = require('domready')
+messages = require('./messages.coffee')
+
+domready ->
+  messages.sayHi()

--- a/components/users/src/main/coffeescript/messages.coffee
+++ b/components/users/src/main/coffeescript/messages.coffee
@@ -1,0 +1,4 @@
+module.exports =
+  greeting: "Hello from the script of Coffee, yummy coffee",
+  sayHi: ->
+    console.log(@greeting)

--- a/components/users/src/main/javascript/app.js
+++ b/components/users/src/main/javascript/app.js
@@ -1,0 +1,6 @@
+var domready = require("domready");
+var messages = require('./messages');
+
+domready(function () {
+    messages.sayHi();
+});

--- a/components/users/src/main/javascript/config.js
+++ b/components/users/src/main/javascript/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    apiUrl: 'http://localhost:3030'
+};

--- a/components/users/src/main/javascript/messages.js
+++ b/components/users/src/main/javascript/messages.js
@@ -1,0 +1,9 @@
+var config = require('./config');
+
+module.exports = {
+    greeting: "Hello from the script of JavaScript",
+    sayHi: function () {
+        console.log(this.greeting);
+        console.log("The current apiUrl is " + config.apiUrl);
+    }
+};

--- a/components/users/src/main/resources/META-INF/resources/home.jsp
+++ b/components/users/src/main/resources/META-INF/resources/home.jsp
@@ -1,6 +1,0 @@
-<html>
-<head></head>
-<body>
-Hello world!
-</body>
-</html>

--- a/components/users/src/main/resources/META-INF/resources/views/home.jsp
+++ b/components/users/src/main/resources/META-INF/resources/views/home.jsp
@@ -1,0 +1,19 @@
+<html>
+<head>
+    <link rel="stylesheet" type="text/css" href="/styles/vendor.css"/>
+    <link rel="stylesheet" type="text/css" href="/styles/app.css"/>
+</head>
+<body>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-6 col-md-offset-3 text-center">
+            <h1>Hello world!</h1>
+        </div>
+    </div>
+</div>
+<script src="/js/vendor.js"></script>
+<script src="/js/app.js"></script>
+<script src="/js/app.coffee.js"></script>
+</body>
+
+</html>

--- a/components/users/src/main/scss/test.scss
+++ b/components/users/src/main/scss/test.scss
@@ -1,0 +1,3 @@
+.test {
+    height: 25px;
+}

--- a/components/users/src/test/java/coffeescript/karma.conf.coffee
+++ b/components/users/src/test/java/coffeescript/karma.conf.coffee
@@ -1,0 +1,41 @@
+module.exports = (config) ->
+  config.set
+    reporters: ['dots']
+
+    preprocessors:
+      '**/*.coffee': ['coffee']
+
+    autoWatch: true
+    basePath: '../'
+    frameworks: ['jasmine']
+    exclude: []
+    port: 8080
+
+  # Start these browsers, currently available:
+  # - Chrome
+  # - ChromeCanary
+  # - Firefox
+  # - Opera
+  # - Safari (only Mac)
+  # - PhantomJS
+  # - IE (only Windows)
+    browsers: [
+      'PhantomJS'
+    ]
+
+  # Which plugins to enable
+    plugins: [
+      'karma-coffee-preprocessor',
+      'karma-phantomjs-launcher',
+      'karma-jasmine',
+      'karma-spec-reporter'
+    ]
+
+  # Continuous Integration mode
+  # if true, it capture browsers, run tests and exit
+  # singleRun: true,
+    colors: true
+
+  # level of logging
+  # possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+    logLevel: config.LOG_INFO


### PR DESCRIPTION
Added a JavaScript build to the Users component. It uses Gulp and a gulp Gradle plugin to build Javascript (done in a CommonJS style, using browserify) into the static assets directory of the users component. This opens the door for a few next steps I'd like to investigate:
- Try using straight NPM plugin for Gradle instead of Gulp plugin (like in spring.io/sagen repo)
- Investigate using WebJars instead of building to the static assets directory
- Play around with some other folder configurations. Like, should we separate JS and Java at the top level, or does it make sense to have /src directory with multiple language folders in it?